### PR TITLE
Ie in compatible mode was returning false for _.isFalsy(null);

### DIFF
--- a/boiler.js
+++ b/boiler.js
@@ -984,8 +984,7 @@
     };
 
   _.isFalsy = function (obj) {
-    return (_.isUndefined(obj) || _.isNull(obj) || _.isNaN(obj) ||
-      obj === "" || obj === 0 || (_.isBool(obj) && Boolean(obj) === false));
+    return !obj;
   };
 
   _.isInfinite = function (obj) {


### PR DESCRIPTION
Your code is slower than native way to check for falsy, and was returning wrong in IE (compatibility mode)
http://jsperf.com/boiler-vs-me
